### PR TITLE
Use retry-after header

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -759,7 +759,7 @@ impl SyncError {
     pub fn is_rate_limited(&self) -> bool {
         match self {
             Self::Backend {
-                source: SyncBackendError::RateLimited,
+                source: SyncBackendError::RateLimited(_),
             } => true,
             _ => false,
         }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -759,7 +759,7 @@ impl SyncError {
     pub fn is_rate_limited(&self) -> bool {
         match self {
             Self::Backend {
-                source: SyncBackendError::RateLimited(_),
+                source: SyncBackendError::RateLimited { .. },
             } => true,
             _ => false,
         }

--- a/src/roblox_web_api.rs
+++ b/src/roblox_web_api.rs
@@ -251,7 +251,4 @@ pub enum RobloxApiError {
         body: String,
         headers: HeaderMap,
     },
-
-    #[error("Tarmac did not receive a retry-after header from Roblox")]
-    MissingRetryHeader,
 }

--- a/src/roblox_web_api.rs
+++ b/src/roblox_web_api.rs
@@ -251,4 +251,7 @@ pub enum RobloxApiError {
         body: String,
         headers: HeaderMap,
     },
+
+    #[error("Tarmac did not receive a retry-after header from Roblox")]
+    MissingRetryHeader,
 }

--- a/src/roblox_web_api.rs
+++ b/src/roblox_web_api.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use reqwest::{
-    header::{HeaderValue, COOKIE},
+    header::{HeaderMap, HeaderValue, COOKIE},
     Client, Request, Response, StatusCode,
 };
 use serde::{Deserialize, Serialize};
@@ -171,6 +171,7 @@ impl RobloxApiClient {
             Err(RobloxApiError::ResponseError {
                 status: response.status(),
                 body,
+                headers: response.headers().clone(),
             })
         }
     }
@@ -245,5 +246,9 @@ pub enum RobloxApiError {
     },
 
     #[error("Roblox API returned HTTP {status} with body: {body}")]
-    ResponseError { status: StatusCode, body: String },
+    ResponseError {
+        status: StatusCode,
+        body: String,
+        headers: HeaderMap,
+    },
 }

--- a/src/sync_backend.rs
+++ b/src/sync_backend.rs
@@ -146,10 +146,10 @@ impl<InnerSyncBackend: SyncBackend> SyncBackend for RetryBackend<InnerSyncBacken
                 Err(Error::RateLimited(retry_after)) => {
                     let time = max(self.min_delay, Duration::new(retry_after, 0));
                     log::info!(
-                        "tarmac is being rate limited, retrying upload after {:?} ({} of {} retries)",
+                        "tarmac is being rate limited, retrying upload after {:?} ({} of {} tries failed)",
                         time,
                         index,
-                        self.max_attempts - 1
+                        self.max_attempts
                     );
                     thread::sleep(time);
                     if index == self.max_attempts {

--- a/src/sync_backend.rs
+++ b/src/sync_backend.rs
@@ -69,10 +69,8 @@ impl<'a> SyncBackend for RobloxSyncBackend<'a> {
             }) => Err(Error::RateLimited {
                 wait_seconds: headers
                     .get("retry-after")
-                    .map(|header| header.to_str().ok())
-                    .flatten()
-                    .map(|header| header.parse().ok())
-                    .flatten(),
+                    .and_then(|header| header.to_str().ok())
+                    .and_then(|header| header.parse().ok()),
             }),
 
             Err(err) => Err(err.into()),

--- a/src/sync_backend.rs
+++ b/src/sync_backend.rs
@@ -69,11 +69,10 @@ impl<'a> SyncBackend for RobloxSyncBackend<'a> {
             }) => Err(Error::RateLimited {
                 wait_seconds: headers
                     .get("retry-after")
-                    .ok_or(RobloxApiError::MissingRetryHeader)?
-                    .to_str()
-                    .unwrap()
-                    .parse()
-                    .ok(),
+                    .map(|header| header.to_str().ok())
+                    .flatten()
+                    .map(|header| header.parse().ok())
+                    .flatten(),
             }),
 
             Err(err) => Err(err.into()),


### PR DESCRIPTION
Roblox now includes this header, which specifies the cooldown time in seconds. There's not much point retrying before this cooldown, so with this PR, Tarmac uses the **longer** of the header and the --retry-delay option. Users can specify --retry-delay 0 to always use the header time.